### PR TITLE
Add export functionality for saving figures in multiple formats

### DIFF
--- a/examples/export_example.py
+++ b/examples/export_example.py
@@ -1,0 +1,151 @@
+"""
+Example script demonstrating the use of seaborn's export functionality.
+"""
+import os
+import matplotlib.pyplot as plt
+import seaborn as sns
+import numpy as np
+import pandas as pd
+
+# Import export functions directly
+from seaborn.export import save_figure, export_legend
+
+# Set the style
+sns.set_theme(style="whitegrid")
+
+# Create a directory for our exported figures if it doesn't exist
+os.makedirs("exported_figures", exist_ok=True)
+
+# Example 1: Simple line plot with multiple export formats
+def example_line_plot():
+    print("Creating and exporting a line plot...")
+
+    # Generate some data
+    x = np.linspace(0, 10, 100)
+    y = np.sin(x)
+
+    # Create a simple line plot
+    plt.figure(figsize=(10, 6))
+    plt.plot(x, y, linewidth=2.5)
+    plt.title("Sine Wave", fontsize=16)
+    plt.xlabel("X", fontsize=14)
+    plt.ylabel("sin(x)", fontsize=14)
+
+    # Export in multiple formats
+    paths = save_figure(
+        path="exported_figures/sine_wave",
+        formats=["png", "pdf", "svg"],
+        dpi=300
+    )
+
+    print(f"Line plot exported to: {paths}")
+    plt.close()
+
+# Example 2: Scatter plot with hue and legend export
+def example_scatter_plot():
+    print("Creating and exporting a scatter plot with legend...")
+
+    # Load the tips dataset
+    tips = sns.load_dataset("tips")
+
+    # Create a scatter plot
+    plt.figure(figsize=(10, 8))
+    scatter = sns.scatterplot(
+        data=tips,
+        x="total_bill",
+        y="tip",
+        hue="time",
+        size="size",
+        sizes=(20, 200),
+        palette="viridis"
+    )
+
+    plt.title("Tips vs Total Bill by Time of Day", fontsize=16)
+    plt.xlabel("Total Bill ($)", fontsize=14)
+    plt.ylabel("Tip ($)", fontsize=14)
+
+    # Get the legend
+    legend = plt.gca().get_legend()
+
+    # Export the main figure
+    paths = save_figure(
+        path="exported_figures/tips_scatter",
+        formats=["png", "jpg"],
+        dpi=300
+        # Note: quality parameter removed as it might not be supported by all backends
+    )
+
+    # Export just the legend
+    legend_paths = export_legend(
+        legend,
+        path="exported_figures/tips_legend",
+        formats=["png", "pdf"]
+    )
+
+    print(f"Scatter plot exported to: {paths}")
+    print(f"Legend exported to: {legend_paths}")
+    plt.close()
+
+# Example 3: Simple barplot visualization
+def example_barplot():
+    print("Creating and exporting a barplot...")
+
+    # Create some sample data
+    categories = ['A', 'B', 'C', 'D', 'E']
+    values = [5, 7, 3, 8, 4]
+
+    # Create a barplot
+    plt.figure(figsize=(10, 6))
+    barplot = sns.barplot(x=categories, y=values)
+
+    plt.title("Sample Barplot", fontsize=16)
+    plt.xlabel("Categories", fontsize=14)
+    plt.ylabel("Values", fontsize=14)
+
+    # Export with transparent background
+    paths = save_figure(
+        path="exported_figures/sample_barplot",
+        formats=["png", "tiff"],
+        dpi=300,
+        transparent=True
+    )
+
+    print(f"Barplot exported to: {paths}")
+    plt.close()
+
+# Example 4: Multiple plots in a grid
+def example_grid_plot():
+    print("Creating and exporting a grid of plots...")
+
+    # Load the iris dataset
+    iris = sns.load_dataset("iris")
+
+    # Create a pairplot
+    pairplot = sns.pairplot(
+        iris,
+        hue="species",
+        height=2.5,
+        corner=True
+    )
+
+    # Export the pairplot
+    paths = save_figure(
+        fig=pairplot.fig,
+        path="exported_figures/iris_pairplot",
+        formats=["png", "pdf"],
+        dpi=300
+    )
+
+    print(f"Pairplot exported to: {paths}")
+    plt.close()
+
+if __name__ == "__main__":
+    print("Running seaborn export examples...")
+
+    # Run all examples
+    example_line_plot()
+    example_scatter_plot()
+    example_barplot()
+    example_grid_plot()
+
+    print("\nAll examples completed. Check the 'exported_figures' directory for the results.")

--- a/seaborn/__init__.py
+++ b/seaborn/__init__.py
@@ -10,6 +10,7 @@ from .matrix import *  # noqa: F401,F403
 from .miscplot import *  # noqa: F401,F403
 from .axisgrid import *  # noqa: F401,F403
 from .widgets import *  # noqa: F401,F403
+from .export import *  # noqa: F401,F403
 from .colors import xkcd_rgb, crayons  # noqa: F401
 from . import cm  # noqa: F401
 

--- a/seaborn/export.py
+++ b/seaborn/export.py
@@ -1,0 +1,191 @@
+"""Functions for exporting seaborn plots in various file formats."""
+import os
+import inspect
+import matplotlib.pyplot as plt
+from typing import Optional, Union, List, Tuple
+import warnings
+
+__all__ = ["save_figure"]
+
+
+def save_figure(
+    fig: Optional[plt.Figure] = None,
+    path: str = "seaborn_plot",
+    formats: Union[str, List[str]] = "png",
+    dpi: int = 300,
+    quality: Optional[int] = None,
+    transparent: bool = False,
+    bbox_inches: str = "tight",
+    pad_inches: float = 0.1,
+    facecolor: Optional[str] = None,
+    **kwargs
+) -> List[str]:
+    """
+    Save a matplotlib figure in one or multiple file formats.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure, optional
+        The figure to save. If None, uses the current figure.
+    path : str, optional
+        The path where the figure should be saved, without file extension.
+        Default is 'seaborn_plot'.
+    formats : str or list of str, optional
+        The file format(s) to save the figure in. Can be a single format or
+        a list of formats. Supported formats include 'png', 'jpg', 'jpeg',
+        'pdf', 'svg', 'eps', 'tif', 'tiff', etc. Default is 'png'.
+    dpi : int, optional
+        The resolution in dots per inch. Default is 300.
+    quality : int, optional
+        For JPEG format only, the image quality from 1 to 100. Default is None,
+        which uses the default quality setting.
+    transparent : bool, optional
+        If True, the figure background will be transparent (for formats that
+        support transparency). Default is False.
+    bbox_inches : str, optional
+        Bounding box in inches. If 'tight', tries to figure out the tight bbox
+        of the figure. Default is 'tight'.
+    pad_inches : float, optional
+        Amount of padding when bbox_inches is 'tight'. Default is 0.1.
+    facecolor : str, optional
+        The figure facecolor. Default is None, which uses the current figure
+        facecolor.
+    **kwargs
+        Additional keyword arguments passed to plt.savefig().
+
+    Returns
+    -------
+    saved_paths : list of str
+        List of paths where the figure was saved.
+
+    Examples
+    --------
+    >>> import seaborn as sns
+    >>> import matplotlib.pyplot as plt
+    >>> # Create a simple plot
+    >>> tips = sns.load_dataset("tips")
+    >>> g = sns.scatterplot(data=tips, x="total_bill", y="tip")
+    >>> # Save in multiple formats
+    >>> sns.save_figure(formats=["png", "pdf", "svg"])
+    >>> # Save with specific path and higher resolution
+    >>> sns.save_figure(path="figures/my_plot", dpi=600, formats="tiff")
+    """
+    if fig is None:
+        fig = plt.gcf()
+
+    if isinstance(formats, str):
+        formats = [formats]
+
+    saved_paths = []
+
+    for fmt in formats:
+        fmt = fmt.lower().strip('.')
+
+        # Handle jpg/jpeg consistency
+        if fmt == 'jpg':
+            fmt = 'jpeg'
+
+        # Check if format is supported
+        if fmt not in plt.gcf().canvas.get_supported_filetypes():
+            warnings.warn(f"Format '{fmt}' is not supported by the current backend. "
+                         f"Supported formats are: {plt.gcf().canvas.get_supported_filetypes().keys()}")
+            continue
+
+        # Create the full path with extension
+        full_path = f"{path}.{fmt}"
+
+        # Create directory if it doesn't exist
+        directory = os.path.dirname(full_path)
+        if directory and not os.path.exists(directory):
+            os.makedirs(directory)
+
+        # Set format-specific parameters
+        save_kwargs = kwargs.copy()
+        save_kwargs.update({
+            'dpi': dpi,
+            'bbox_inches': bbox_inches,
+            'pad_inches': pad_inches,
+            'transparent': transparent,
+        })
+
+        if facecolor is not None:
+            save_kwargs['facecolor'] = facecolor
+
+        # Add quality for JPEG
+        if fmt == 'jpeg' and quality is not None:
+            if 1 <= quality <= 100:
+                # Check if the backend supports the quality parameter
+                try:
+                    from matplotlib.backends.backend_agg import FigureCanvasAgg
+                    if hasattr(FigureCanvasAgg, 'print_jpg') and 'quality' in inspect.signature(FigureCanvasAgg.print_jpg).parameters:
+                        save_kwargs['quality'] = quality
+                    else:
+                        warnings.warn("The current matplotlib backend does not support the 'quality' parameter for JPEG. Using default quality.")
+                except (ImportError, AttributeError):
+                    warnings.warn("Could not determine if the current matplotlib backend supports the 'quality' parameter for JPEG. Using default quality.")
+            else:
+                warnings.warn("JPEG quality must be between 1 and 100. Using default quality.")
+
+        # Save the figure
+        fig.savefig(full_path, format=fmt, **save_kwargs)
+        saved_paths.append(full_path)
+
+    return saved_paths
+
+
+def export_legend(
+    legend,
+    path: str = "legend",
+    formats: Union[str, List[str]] = "png",
+    **kwargs
+) -> List[str]:
+    """
+    Export only the legend of a plot to a separate file.
+
+    Parameters
+    ----------
+    legend : matplotlib.legend.Legend
+        The legend to export.
+    path : str, optional
+        The path where the legend should be saved, without file extension.
+        Default is 'legend'.
+    formats : str or list of str, optional
+        The file format(s) to save the legend in. Default is 'png'.
+    **kwargs
+        Additional keyword arguments passed to save_figure().
+
+    Returns
+    -------
+    saved_paths : list of str
+        List of paths where the legend was saved.
+
+    Examples
+    --------
+    >>> import seaborn as sns
+    >>> import matplotlib.pyplot as plt
+    >>> # Create a plot with a legend
+    >>> tips = sns.load_dataset("tips")
+    >>> g = sns.scatterplot(data=tips, x="total_bill", y="tip", hue="time")
+    >>> # Get the legend
+    >>> legend = plt.gca().get_legend()
+    >>> # Export only the legend
+    >>> sns.export_legend(legend, path="figures/time_legend")
+    """
+    fig, ax = plt.subplots(figsize=(5, 5))
+    ax.axis('off')
+
+    # Add the legend to the new figure
+    ax.legend(
+        handles=legend.legend_handles if hasattr(legend, 'legend_handles') else legend.get_legend_handles_labels()[0],
+        labels=[text.get_text() for text in legend.texts] if hasattr(legend, 'texts') else legend.get_legend_handles_labels()[1],
+        title=legend.get_title().get_text() if legend.get_title() else None,
+        frameon=legend.get_frame_on() if hasattr(legend, 'get_frame_on') else True,
+        **{k: getattr(legend, f"get_{k}")() for k in ["framealpha", "edgecolor"]
+           if hasattr(legend, f"get_{k}")}
+    )
+
+    # Save the figure with just the legend
+    saved_paths = save_figure(fig=fig, path=path, formats=formats, **kwargs)
+    plt.close(fig)
+
+    return saved_paths

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,114 @@
+"""Tests for export functionality."""
+import os
+import pytest
+import matplotlib.pyplot as plt
+import numpy as np
+import tempfile
+import shutil
+
+import seaborn as sns
+from seaborn.export import save_figure, export_legend
+
+
+class TestExport:
+    """Test the export functionality."""
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        """Create a temporary directory for test files and clean up after tests."""
+        self.temp_dir = tempfile.mkdtemp()
+        yield
+        plt.close("all")
+        shutil.rmtree(self.temp_dir)
+
+    def test_save_figure_single_format(self):
+        """Test saving a figure in a single format."""
+        # Create a simple plot
+        plt.figure()
+        plt.plot([1, 2, 3], [1, 2, 3])
+
+        # Save in PNG format
+        path = os.path.join(self.temp_dir, "test_plot")
+        saved_paths = save_figure(path=path, formats="png")
+
+        # Check that the file was created
+        assert len(saved_paths) == 1
+        assert os.path.exists(saved_paths[0])
+        assert saved_paths[0].endswith(".png")
+
+    def test_save_figure_multiple_formats(self):
+        """Test saving a figure in multiple formats."""
+        # Create a simple plot
+        plt.figure()
+        plt.plot([1, 2, 3], [1, 2, 3])
+
+        # Save in multiple formats
+        path = os.path.join(self.temp_dir, "test_plot")
+        formats = ["png", "pdf", "svg"]
+        saved_paths = save_figure(path=path, formats=formats)
+
+        # Check that all files were created
+        assert len(saved_paths) == len(formats)
+        for p, fmt in zip(saved_paths, formats):
+            assert os.path.exists(p)
+            assert p.endswith(f".{fmt}")
+
+    def test_save_figure_with_directory_creation(self):
+        """Test saving a figure with automatic directory creation."""
+        # Create a simple plot
+        plt.figure()
+        plt.plot([1, 2, 3], [1, 2, 3])
+
+        # Save in a subdirectory that doesn't exist yet
+        path = os.path.join(self.temp_dir, "subdir", "test_plot")
+        saved_paths = save_figure(path=path, formats="png")
+
+        # Check that the directory and file were created
+        assert os.path.exists(os.path.dirname(saved_paths[0]))
+        assert os.path.exists(saved_paths[0])
+
+    def test_export_legend(self):
+        """Test exporting just the legend."""
+        # Create a plot with a legend
+        plt.figure()
+        for i in range(3):
+            plt.plot([1, 2, 3], [i, i+1, i+2], label=f"Line {i+1}")
+        legend = plt.legend()
+
+        # Export the legend
+        path = os.path.join(self.temp_dir, "test_legend")
+        saved_paths = export_legend(legend, path=path, formats="png")
+
+        # Check that the file was created
+        assert len(saved_paths) == 1
+        assert os.path.exists(saved_paths[0])
+        assert saved_paths[0].endswith(".png")
+
+    def test_save_figure_jpg_format(self):
+        """Test saving a figure in JPEG format."""
+        # Create a simple plot
+        plt.figure()
+        plt.plot([1, 2, 3], [1, 2, 3])
+
+        # Save as JPEG
+        path = os.path.join(self.temp_dir, "test_plot")
+        saved_paths = save_figure(path=path, formats="jpg")
+
+        # Check that the file was created
+        assert len(saved_paths) == 1
+        assert os.path.exists(saved_paths[0])
+        assert saved_paths[0].endswith(".jpeg")  # Note: jpg is converted to jpeg
+
+    def test_save_figure_with_transparent_background(self):
+        """Test saving a figure with transparent background."""
+        # Create a simple plot
+        plt.figure()
+        plt.plot([1, 2, 3], [1, 2, 3])
+
+        # Save with transparent background
+        path = os.path.join(self.temp_dir, "test_plot")
+        saved_paths = save_figure(path=path, formats="png", transparent=True)
+
+        # Check that the file was created
+        assert len(saved_paths) == 1
+        assert os.path.exists(saved_paths[0])


### PR DESCRIPTION
## Description
This PR adds a new export module to seaborn that allows users to easily save figures in multiple file formats with a single function call.

## Features
- `save_figure()`: Save matplotlib figures in various formats (PNG, PDF, SVG, JPEG, TIFF, etc.)
- `export_legend()`: Extract and save just the legend from a plot as a separate file
- Support for controlling resolution (DPI), transparency, and other export parameters
- Comprehensive examples and unit tests

## Use Cases
- Exporting visualizations for publications, presentations, or web content
- Saving the same plot in multiple formats with one command
- Extracting legends for custom layouts

## Testing
All tests are passing, and the example script demonstrates the functionality working correctly.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author